### PR TITLE
Added unit test for passing a date and date YY format

### DIFF
--- a/test.js
+++ b/test.js
@@ -70,8 +70,8 @@ describe('timestamp', function() {
   });
 
   it('should return the 2 digit year for a given date', function() {
-    const date = new Date(2019, 0);
-    const expectedYear = "19";
+    var date = new Date(2019, 0);
+    var expectedYear = "19";
 
     assert.equal(timestamp('YY', date), expectedYear);
     assert.equal(timestampUTC('YY', date), expectedYear);

--- a/test.js
+++ b/test.js
@@ -68,4 +68,13 @@ describe('timestamp', function() {
     var expected = String(new Date().getUTCFullYear());
     assert.equal(timestamp('YYYY'), pad(expected, 4, '0'));
   });
+
+  it('should return the 2 digit year for a given date', function() {
+    const date = new Date(2019, 0);
+    const expectedYear = "19";
+
+    assert.equal(timestamp('YY', date), expectedYear);
+    assert.equal(timestampUTC('YY', date), expectedYear);
+  });
+
 });


### PR DESCRIPTION
## Description
Added a unit test for passing a date object and the `YY` year format.
I found that `YY` wasn't documented in `README.md` but failed to rebuild `README.md`.

I tried to update `.verb.md` but I couldn't build `README.md` using `verb` and a clean master due to `timestamp.utc` being undefined because of the wrapper ge....(down a rabbit hole of debugging).
In other words, running `verb` with the version below doesn't work.
```
"dependencies": {
+    "verb": "github:verbose/verb#dev",
+    "verb-generate-readme": "^0.8.0"
   }
```