### PR TITLE
Changed HH to hh

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@
 
 'use strict';
 
-var dateRegex = /(?=(YYYY|YY|MM|DD|HH|mm|ss|ms))\1([:\/]*)/g;
+var dateRegex = /(?=(YYYY|YY|MM|DD|hh|mm|ss|ms))\1([:\/]*)/g;
 var timespan = {
   YYYY: ['getFullYear', 4],
   YY: ['getFullYear', 2],
   MM: ['getMonth', 2, 1], // getMonth is zero-based, thus the extra increment field
   DD: ['getDate', 2],
-  HH: ['getHours', 2],
+  hh: ['getHours', 2],
   mm: ['getMinutes', 2],
   ss: ['getSeconds', 2],
   ms: ['getMilliseconds', 3]

--- a/test.js
+++ b/test.js
@@ -40,8 +40,8 @@ describe('timestamp', function() {
   });
 
   it('should return hours:', function() {
-    assert(/^\d{2}$/.test(timestamp('HH')));
-    assert(/^\d{2}$/.test(timestampUTC('HH')));
+    assert(/^\d{2}$/.test(timestamp('hh')));
+    assert(/^\d{2}$/.test(timestampUTC('hh')));
   });
 
   it('should return minutes:', function() {


### PR DESCRIPTION
Changed hours from `HH` to `hh` so that hours matches minutes and seconds instead of days/months/years, because `HH:mm:ss` looks weird.

