### PR TITLE
fix(readme): fix link in release history

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -112,4 +112,4 @@ console.log(timestamp.utc('ms'));
 
 **Breaking changes**
 
-Default pattern was changed from `YYYY:MM:DD` to `YYYY-MM-DD`. See [issues/3](../../issues) for more details.
+Default pattern was changed from `YYYY:MM:DD` to `YYYY-MM-DD`. See [issues/3](../../issues/3) for more details.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ console.log(timestamp.utc('ms'));
 
 **Breaking changes**
 
-Default pattern was changed from `YYYY:MM:DD` to `YYYY-MM-DD`. See [issues/3](../../issues) for more details.
+Default pattern was changed from `YYYY:MM:DD` to `YYYY-MM-DD`. See [issues/3](../../issues/3) for more details.
 
 ## About
 


### PR DESCRIPTION
I've never used verb before, I changed both `.verb.md` and `README.md` but I'm not sure if this is the right approach...