### PR TITLE
fix: unable to import module from typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ console.log(timestamp.utc());
 //=> 2018-10-26
 ```
 
+or in typescript:
+
+```ts
+import * as timestamp from 'time-stamp';
+// or if "esModuleInterop": true in tsconfig.json:
+// import timestamp from 'time-stamp'
+
+console.log(timestamp());
+//=> 2018-10-26
+
+console.log(timestamp.utc());
+//=> 2018-10-26
+```
+
 ## Customizing the timestamp
 
 You may also pass a string to format the generated timestamp.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ console.log(timestamp.utc());
 or in typescript:
 
 ```ts
-import * as timestamp from 'time-stamp';
-// or if "esModuleInterop": true in tsconfig.json:
-// import timestamp from 'time-stamp'
+import timestamp = require('time-stamp');
 
 console.log(timestamp());
 //=> 2018-10-26

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
-declare function timestamp(pattern?: string | Date, date?: Date): string
-declare function timestampUTC(pattern?: string | Date, date?: Date): string
+declare function timestamp(pattern?: string | Date, date?: Date): string;
 
-export default timestamp
-export { timestampUTC as utc };
+declare namespace timestamp {
+  function utc(pattern?: string | Date, date?: Date): string;
+}
+export = timestamp;


### PR DESCRIPTION
Allow import in typescript:
```ts
import timestamp = require('timestamp');
```

EDIT: updated with [typescript recommanded import syntax for commonjs module](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require) as recommanded by @fregante (see below).