### PR TITLE
Implementing time zone change #5

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -22,6 +22,17 @@ console.log(timestamp.utc('YYYYMMDD'));
 //=> {%= timestampUTC('YYYYMMDD') %}
 ```
 
+Setting a global time zone is also possible.
+
+```js
+timestamp.setTimeZone(2); // Set time zone to GMT +2
+console.log(timestamp('YYYYMMDD'));
+//=> {%= setTimeZone(2); timestamp('YYYYMMDD') %}
+
+console.log(timestamp.utc('YYYYMMDD'));
+//=> {%= setTimeZone(2); timestampUTC('YYYYMMDD') %}
+```
+
 **Supported patterns**
 
 - `YYYY`: full year (ex: **{%= timestamp("YYYY") %}**)

--- a/helpers.js
+++ b/helpers.js
@@ -2,3 +2,4 @@ const timestamp = require('./');
 
 exports.timestamp = timestamp;
 exports.timestampUTC = timestamp.utc;
+exports.setTimeZone = timestamp.setTimeZone;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare function timestamp(pattern?: string | Date, date?: Date): string
 declare function timestampUTC(pattern?: string | Date, date?: Date): string
+declare function setTimeZone(timezoneHoursOffset: Number): void
 
 export default timestamp
 export { timestampUTC as utc };

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var dateRegex = /(?=(YYYY|YY|MM|DD|HH|mm|ss|ms))\1([:\/]*)/g;
+var timezoneHoursShift = 0;
 var timespan = {
   YYYY: ['getFullYear', 4],
   YY: ['getFullYear', 2],
@@ -26,6 +27,15 @@ var timestamp = function(str, date, utc) {
   }
 
   if (!date) date = new Date();
+  if (timezoneHoursShift !== 0) {
+    var tempDate = new Date(date);
+    if (!utc) {
+      tempDate.setHours(tempDate.getUTCHours() + timezoneHoursShift);
+    } else {
+      tempDate.setHours(tempDate.getUTCHours() + timezoneHoursShift - date.getTimezoneOffset() / 60);
+    }
+    date = tempDate;
+  }
   return str.replace(dateRegex, function(match, key, rest) {
     var args = timespan[key];
     var name = args[0];
@@ -38,6 +48,10 @@ var timestamp = function(str, date, utc) {
 
 timestamp.utc = function(str, date) {
   return timestamp(str, date, true);
+};
+
+timestamp.setTimeZone = function (hourDifference) {
+  timezoneHoursShift = hourDifference;
 };
 
 module.exports = timestamp;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-var dateRegex = /(?=(YYYY|YY|MM|DD|HH|mm|ss|ms))\1([:\/]*)/g;
+var dateRegex = /(?=(YYYY|YY|MM|DD|HH|mm|ss|ms))\1([:/]*)/g;
 var timezoneHoursShift = 0;
 var timespan = {
   YYYY: ['getFullYear', 4],
@@ -50,7 +50,7 @@ timestamp.utc = function(str, date) {
   return timestamp(str, date, true);
 };
 
-timestamp.setTimeZone = function (hourDifference) {
+timestamp.setTimeZone = function(hourDifference) {
   timezoneHoursShift = hourDifference;
 };
 

--- a/test.js
+++ b/test.js
@@ -75,9 +75,10 @@ describe('timestamp', function() {
   it('should return the 2 digit year for a given date', function() {
     var date = new Date(2019, 0);
     var expectedYear = "19";
+    var expectedYearUTC = String(date.getUTCFullYear()).substr(2);
 
     assert.equal(timestamp('YY', date), expectedYear);
-    assert.equal(timestampUTC('YY', date), expectedYear);
+    assert.equal(timestampUTC('YY', date), expectedYearUTC);
   });
 
   it('should use GMT +2 for the given date', function () {

--- a/test.js
+++ b/test.js
@@ -5,6 +5,9 @@ var assert = require('assert');
 var pad = require('pad-left');
 var timestamp = require('./');
 var timestampUTC = require('./').utc;
+var safeHour = function (hour) {
+    return (24 + hour) % 24;
+};
 
 describe('timestamp', function() {
   it('should return the default timestamp:', function() {
@@ -77,4 +80,50 @@ describe('timestamp', function() {
     assert.equal(timestampUTC('YY', date), expectedYear);
   });
 
+  it('should use GMT +2 for the given date', function () {
+    var date = new Date("2019-01-01T00:00:00");
+    var timezoneHoursShift = 2;
+    var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60;
+    var expectedHoursUTC = timezoneHoursShift + date.getUTCHours();
+    expectedHours = safeHour(expectedHours);
+    expectedHoursUTC = safeHour(expectedHoursUTC);
+    timestamp.setTimeZone(timezoneHoursShift);
+    assert.equal(timestamp('HH', date), pad(expectedHours, 2, '0'));
+    assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
+  });
+
+  it('should use GMT -2 for the given date', function () {
+    var date = new Date("2019-01-01T00:00:00");
+    var timezoneHoursShift = -2;
+    var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60;
+    var expectedHoursUTC = timezoneHoursShift + date.getUTCHours();
+    expectedHours = safeHour(expectedHours);
+    expectedHoursUTC = safeHour(expectedHoursUTC);
+    timestamp.setTimeZone(timezoneHoursShift);
+    assert.equal(timestamp('HH', date), pad(expectedHours, 2, '0'));
+    assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
+  });
+
+  it('should use GMT +2 for the current date', function () {
+    var date = new Date();
+    var timezoneHoursShift = 2;
+    var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60 + date.getHours();
+    var expectedHoursUTC = date.getUTCHours() + timezoneHoursShift;
+    expectedHours = safeHour(expectedHours);
+    expectedHoursUTC = safeHour(expectedHoursUTC);
+    timestamp.setTimeZone(timezoneHoursShift);
+    assert.equal(timestamp('HH', date), pad(expectedHours, 2, '0'));
+    assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
+  });
+
+  it('should use GMT -2 for the current date', function () {
+    var date = new Date();
+    var timezoneHoursShift = -2;
+    var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60 + date.getHours();
+    var expectedHoursUTC = date.getUTCHours() + timezoneHoursShift;
+    expectedHours = safeHour(expectedHours);
+    timestamp.setTimeZone(timezoneHoursShift);
+    assert.equal(timestamp('HH', date), pad(expectedHours, 2, '0'));
+    assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
+  });
 });

--- a/test.js
+++ b/test.js
@@ -5,8 +5,8 @@ var assert = require('assert');
 var pad = require('pad-left');
 var timestamp = require('./');
 var timestampUTC = require('./').utc;
-var safeHour = function (hour) {
-    return (24 + hour) % 24;
+var safeHour = function(hour) {
+  return (24 + hour) % 24;
 };
 
 describe('timestamp', function() {
@@ -74,15 +74,15 @@ describe('timestamp', function() {
 
   it('should return the 2 digit year for a given date', function() {
     var date = new Date(2019, 0);
-    var expectedYear = "19";
+    var expectedYear = '19';
     var expectedYearUTC = String(date.getUTCFullYear()).substr(2);
 
     assert.equal(timestamp('YY', date), expectedYear);
     assert.equal(timestampUTC('YY', date), expectedYearUTC);
   });
 
-  it('should use GMT +2 for the given date', function () {
-    var date = new Date("2019-01-01T00:00:00");
+  it('should use GMT +2 for the given date', function() {
+    var date = new Date('2019-01-01T00:00:00');
     var timezoneHoursShift = 2;
     var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60;
     var expectedHoursUTC = timezoneHoursShift + date.getUTCHours();
@@ -93,8 +93,8 @@ describe('timestamp', function() {
     assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
   });
 
-  it('should use GMT -2 for the given date', function () {
-    var date = new Date("2019-01-01T00:00:00");
+  it('should use GMT -2 for the given date', function() {
+    var date = new Date('2019-01-01T00:00:00');
     var timezoneHoursShift = -2;
     var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60;
     var expectedHoursUTC = timezoneHoursShift + date.getUTCHours();
@@ -105,7 +105,7 @@ describe('timestamp', function() {
     assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
   });
 
-  it('should use GMT +2 for the current date', function () {
+  it('should use GMT +2 for the current date', function() {
     var date = new Date();
     var timezoneHoursShift = 2;
     var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60 + date.getHours();
@@ -117,7 +117,7 @@ describe('timestamp', function() {
     assert.equal(timestampUTC('HH', date), pad(expectedHoursUTC, 2, '0'));
   });
 
-  it('should use GMT -2 for the current date', function () {
+  it('should use GMT -2 for the current date', function() {
     var date = new Date();
     var timezoneHoursShift = -2;
     var expectedHours = timezoneHoursShift + date.getTimezoneOffset() / 60 + date.getHours();


### PR DESCRIPTION
Hi!  
This PR aims to implement the feature described in #5.  
Here are some of the things I did:
 - Implement a time zone changing feature
 - Update docs
 - Write tests for the new change
 - Fix a previous test

I'm not sure what OP meant by setting time zone, the way I did it is it sets the timezone from the UTC time.
**Example**:
Let's suppose the time is 19:00:00 on a machine that's timezone is GMT +1.  
We set time the timezone to GMT +2.  
In this case my feature would return 20:00:00, because it's +2 from UTC time, and not from the given time.  

**Previous test case, that was broken**:
I fixed a test case where it was testing the 2 digit format.  
In this test case the input date is `2019-01-01 00:00:00` but with the GMT offset of the current machine, in my case this offset is +1, so the UTC date for me was `2018-12-31 23:00:00`, which gives the 2 digit year of `18` instead of the expected `19`

**Building the docs**:
I've read the guide in the readme file on building the docs, however I was unable to build the docs, because of an error that says `TypeError: expected helpers to be an object`.  
If you could help me with what's wrong I could build the docs, because I'm not so familiar with `verb`.  
I tried searching the docs but I haven't found anything related to the "helpers" package.json option.